### PR TITLE
Removing Unnecessary math operation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,7 +128,7 @@ impl BinaryReader {
     }
 
     pub fn align(&mut self, size: usize) {
-        self.pos = (self.pos + size - 1) / size * size
+        self.pos = self.pos + size - 1
     }
 
     /// Read provided length size bytes.


### PR DESCRIPTION
I scoured through the code when came across this math operation, and it kind off bugged me because it wasn't necessary (to my knowledge).
To my math knowledge the last part `/ size * size` cancels itself out, but if there is any reason why this was added to the end, I would like to be educated on why so.

Thanks for making this lib. A simple way of reading a byte buffer was exactly what I was looking for.